### PR TITLE
Composable class Outcome<F,S>

### DIFF
--- a/src/main/java/io/vlingo/common/fn/outcome/Failure.java
+++ b/src/main/java/io/vlingo/common/fn/outcome/Failure.java
@@ -1,0 +1,58 @@
+package io.vlingo.common.fn.outcome;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Failure<Cause extends RuntimeException, Value> implements Outcome<Cause, Value> {
+    private final Cause cause;
+
+    private Failure(Cause cause) {
+        this.cause = cause;
+    }
+
+    public static <Cause extends RuntimeException, Value> Outcome<Cause, Value> of(Cause cause) {
+        return new Failure<>(cause);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <NextSuccess> Outcome<Cause, NextSuccess> andThen(Function<Value, NextSuccess> action) {
+        return (Outcome<Cause, NextSuccess>) this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <NextFailure extends Throwable, NextSuccess> Outcome<NextFailure, NextSuccess> andThenInto(Function<Value, Outcome<NextFailure, NextSuccess>> action) {
+        return (Outcome<NextFailure, NextSuccess>) this;
+    }
+
+    @Override
+    public void atLeastConsume(Consumer<Value> consumer) {
+
+    }
+
+    @Override
+    public Outcome<Cause, Value> otherwise(Function<Cause, Value> action) {
+        return Success.of(action.apply(cause));
+    }
+
+    @Override
+    public <NextFailure extends Throwable, NextSuccess> Outcome<NextFailure, NextSuccess> otherwiseInto(Function<Cause, Outcome<NextFailure, NextSuccess>> action) {
+        return action.apply(cause);
+    }
+
+    @Override
+    public Value get() throws Cause {
+        throw cause;
+    }
+
+    @Override
+    public Value getOrNull() {
+        return null;
+    }
+
+    @Override
+    public <NextSuccess> NextSuccess resolve(Function<Cause, NextSuccess> onFailedOutcome, Function<Value, NextSuccess> onSuccessfulOutcome) {
+        return onFailedOutcome.apply(cause);
+    }
+}

--- a/src/main/java/io/vlingo/common/fn/outcome/Outcome.java
+++ b/src/main/java/io/vlingo/common/fn/outcome/Outcome.java
@@ -19,6 +19,8 @@ public interface Outcome<Failure extends Throwable, Success> {
 
     Success get() throws Failure;
 
+    Success getOrNull();
+
     <NextSuccess>
     NextSuccess resolve(
             final Function<Failure, NextSuccess> onFailedOutcome,

--- a/src/main/java/io/vlingo/common/fn/outcome/Outcome.java
+++ b/src/main/java/io/vlingo/common/fn/outcome/Outcome.java
@@ -1,0 +1,27 @@
+package io.vlingo.common.fn.outcome;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface Outcome<Failure extends Throwable, Success> {
+    <NextSuccess>
+    Outcome<Failure, NextSuccess> andThen(final Function<Success, NextSuccess> action);
+
+    <NextFailure extends Throwable, NextSuccess>
+    Outcome<NextFailure, NextSuccess> andThenInto(final Function<Success, Outcome<NextFailure, NextSuccess>> action);
+
+    void atLeastConsume(final Consumer<Success> consumer);
+
+    Outcome<Failure, Success> otherwise(final Function<Failure, Success> action);
+
+    <NextFailure extends Throwable, NextSuccess>
+    Outcome<NextFailure, NextSuccess> otherwiseInto(final Function<Failure, Outcome<NextFailure, NextSuccess>> action);
+
+    Success get() throws Failure;
+
+    <NextSuccess>
+    NextSuccess resolve(
+            final Function<Failure, NextSuccess> onFailedOutcome,
+            final Function<Success, NextSuccess> onSuccessfulOutcome
+    );
+}

--- a/src/main/java/io/vlingo/common/fn/outcome/OutcomeConversions.java
+++ b/src/main/java/io/vlingo/common/fn/outcome/OutcomeConversions.java
@@ -1,0 +1,11 @@
+package io.vlingo.common.fn.outcome;
+
+import java.util.Optional;
+
+public final class OutcomeConversions {
+    private OutcomeConversions() {}
+
+    public static Optional<Integer> asOptional(Outcome<RuntimeException, Integer> outcome) {
+        return outcome.resolve(ex -> Optional.empty(), Optional::of);
+    }
+}

--- a/src/main/java/io/vlingo/common/fn/outcome/Success.java
+++ b/src/main/java/io/vlingo/common/fn/outcome/Success.java
@@ -1,0 +1,57 @@
+package io.vlingo.common.fn.outcome;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Success<Failure extends RuntimeException, Value> implements Outcome<Failure, Value> {
+    private final Value value;
+
+    private Success(Value value) {
+        this.value = value;
+    }
+
+    public static <Failure extends RuntimeException, Value> Outcome<Failure, Value> of(Value value) {
+        return new Success<>(value);
+    }
+
+    @Override
+    public <NextSuccess> Outcome<Failure, NextSuccess> andThen(Function<Value, NextSuccess> action) {
+        return Success.of(action.apply(value));
+    }
+
+    @Override
+    public <NextFailure extends Throwable, NextSuccess> Outcome<NextFailure, NextSuccess> andThenInto(Function<Value, Outcome<NextFailure, NextSuccess>> action) {
+        return action.apply(value);
+    }
+
+    @Override
+    public void atLeastConsume(Consumer<Value> consumer) {
+        consumer.accept(value);
+    }
+
+    @Override
+    public Outcome<Failure, Value> otherwise(Function<Failure, Value> action) {
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <NextFailure extends Throwable, NextSuccess> Outcome<NextFailure, NextSuccess> otherwiseInto(Function<Failure, Outcome<NextFailure, NextSuccess>> action) {
+        return (Outcome<NextFailure, NextSuccess>) this;
+    }
+
+    @Override
+    public Value get() throws Failure {
+        return value;
+    }
+
+    @Override
+    public Value getOrNull() {
+        return value;
+    }
+
+    @Override
+    public <NextSuccess> NextSuccess resolve(Function<Failure, NextSuccess> onFailedOutcome, Function<Value, NextSuccess> onSuccessfulOutcome) {
+        return onSuccessfulOutcome.apply(value);
+    }
+}

--- a/src/test/java/io/vlingo/common/fn/outcome/OutcomeConversionsTest.java
+++ b/src/test/java/io/vlingo/common/fn/outcome/OutcomeConversionsTest.java
@@ -1,0 +1,33 @@
+package io.vlingo.common.fn.outcome;
+
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class OutcomeConversionsTest {
+    @Test
+    public void testThatASuccessOutcomeIsTransformedToAValidOptional() {
+        final int value = randomInteger();
+        final Optional<Integer> outcome = OutcomeConversions.asOptional(Success.of(value));
+
+        assertEquals(outcome, Optional.of(value));
+    }
+
+    @Test
+    public void testThatAFailedOutcomeIsTransformedToAnEmptyOptional() {
+        final Optional<Integer> outcome = OutcomeConversions.asOptional(Failure.of(randomException()));
+
+        assertEquals(outcome, Optional.empty());
+    }
+
+    private int randomInteger() {
+        return new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private RuntimeException randomException() {
+        return new RuntimeException();
+    }
+}

--- a/src/test/java/io/vlingo/common/fn/outcome/OutcomeTest.java
+++ b/src/test/java/io/vlingo/common/fn/outcome/OutcomeTest.java
@@ -1,0 +1,175 @@
+package io.vlingo.common.fn.outcome;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class OutcomeTest {
+    @Test
+    public void testThatASuccessfulOutcomeCanBeResolved() {
+        final int initialValue = randomInteger();
+        final int failedValue = randomInteger();
+        final int successInt = randomInteger();
+        final int expected = successInt * initialValue;
+
+        final int outcome = Success.of(initialValue).resolve(ex -> failedValue, value -> value * successInt);
+        assertEquals(expected, outcome);
+    }
+
+    @Test
+    public void testThatASuccessfulOutcomeCanBeComposed() {
+        final int initialValue = randomInteger();
+        final int successInt = randomInteger();
+        final int expected = initialValue * successInt;
+
+        final int outcome = Success.of(initialValue).andThen(value -> value * successInt).get();
+        assertEquals(expected, outcome);
+    }
+
+    @Test
+    public void testThatASuccessfulOutcomeCanBeComposedWithANewOutcome() {
+        final int initialValue = randomInteger();
+        final int successInt = randomInteger();
+        final int expected = initialValue * successInt;
+
+        final int outcome = Success.of(initialValue).andThenInto(value -> Success.of(value * successInt)).get();
+        assertEquals(expected, outcome);
+    }
+
+    @Test
+    public void testThatAtLeastConsumedIsCalledWhenASuccess() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        final int initialValue = randomInteger();
+
+        Success.of(initialValue).atLeastConsume(currentValue::set);
+        assertEquals(initialValue, currentValue.get());
+    }
+
+    @Test
+    public void testThatOtherwiseIsNotCalledWhenSuccess() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        final int initialValue = randomInteger();
+
+        Outcome<RuntimeException, Integer> success = Success.of(initialValue);
+        Outcome<RuntimeException, Integer> otherwise = success.otherwise(ex -> {
+            currentValue.set(initialValue);
+            return initialValue;
+        });
+
+        assertEquals(0, currentValue.get());
+        assertEquals(success, otherwise);
+    }
+
+    @Test
+    public void testThatOtherwiseIntoIsNotCalledWhenSuccess() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        final int initialValue = randomInteger();
+
+        Outcome<RuntimeException, Integer> success = Success.of(initialValue);
+        Outcome<RuntimeException, Integer> otherwise = success.otherwiseInto(ex -> {
+            currentValue.set(initialValue);
+            return Success.of(initialValue);
+        });
+
+        assertEquals(0, currentValue.get());
+        assertEquals(success, otherwise);
+    }
+
+    @Test
+    public void testThatGetOrNullReturnsTheValueWhenSuccess() {
+        final int initialValue = randomInteger();
+        final int outcome = Success.of(initialValue).getOrNull();
+
+        assertEquals(outcome, initialValue);
+    }
+
+    @Test
+    public void testThatAFailureIsNotComposedWithAndThen() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        Failure.<RuntimeException, Integer>of(randomException()).andThen(currentValue::getAndSet);
+        assertEquals(0, currentValue.get());
+    }
+
+    @Test
+    public void testThatAFailureIsNotComposedWithAndThenInto() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        Failure.<RuntimeException, Integer>of(randomException())
+                .andThenInto(value -> Success.of(currentValue.getAndSet(value)));
+
+        assertEquals(0, currentValue.get());
+    }
+
+    @Test
+    public void testThatAFailureIsNotComposedWithAtLeastConsume() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        Failure.<RuntimeException, Integer>of(randomException()).atLeastConsume(currentValue::set);
+
+        assertEquals(0, currentValue.get());
+    }
+
+    @Test
+    public void testThatAFailureIsRecoveredWithOtherwise() {
+        final int recoveredValue = randomInteger();
+        final int outcome = Failure.<RuntimeException, Integer>of(randomException())
+            .otherwise(ex -> recoveredValue)
+            .get();
+
+        assertEquals(outcome, recoveredValue);
+    }
+
+    @Test
+    public void testThatAFailureIsRecoveredWithOtherwiseInto() {
+        final int recoveredValue = randomInteger();
+        final int outcome = Failure.<RuntimeException, Integer>of(randomException())
+            .otherwiseInto(ex -> Success.of(recoveredValue))
+            .get();
+
+        assertEquals(outcome, recoveredValue);
+    }
+
+    @Test
+    public void testThatGetOnAFailureThrowsTheCauseOfFailure() {
+        final RuntimeException exception = randomException();
+        try {
+            Failure.<RuntimeException, Integer>of(exception).get();
+            fail("Expected exception was not thrown.");
+        } catch (RuntimeException e) {
+            assertEquals(exception, e);
+        }
+    }
+
+    @Test
+    public void testThatGetOrNullReturnsNullOnAFailure() {
+        assertNull(Failure.<RuntimeException, Integer>of(randomException()).getOrNull());
+    }
+
+    @Test
+    public void testThatResolveGoesThroughTheFailureBranchWhenFailedOutcome() {
+        final AtomicInteger currentValue = new AtomicInteger(0);
+        final int failedBranch = randomInteger();
+        final int successBranch = randomInteger();
+
+        final int outcome = Failure.of(randomException())
+                .resolve(ex -> {
+                    currentValue.set(failedBranch);
+                    return failedBranch;
+                }, v -> currentValue.getAndSet(successBranch));
+
+        assertEquals(outcome, currentValue.get());
+        assertEquals(currentValue.get(), failedBranch);
+    }
+
+    private int randomInteger() {
+        return new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private RuntimeException randomException() {
+        return new RuntimeException();
+    }
+}


### PR DESCRIPTION
This is the signature for `Outcome<Failure, Success>` so we can verify that the implementation will be as expected.

If is there any improvement or you find that the interface lacks of a method that you would like to have, feel free to ask for it 😄 .

And I would like also to know if we want to have some functional methods that are quite common on those kind of 'monadic' behaviours. I'm thinking on:

* `filter(Success -> Boolean)`
* `zipWith(Result<Failure, Success> result)`

And maybe some interop with Java and vlingo:

* `asOptional()`
Will return a Optional<Success> or None in case of Failure

* `asCompletes()`
Will return a Completes<Success> or a failed Completes in case of Failure

## New Methods
* `getOrNull`
Returns the successs or null, as null is the default failure value for vlingo, to support this usage.

* `otherwiseInto`
Transforms a Failure to a new outcome (that can be Success or Failure again)


