### PR TITLE
Completes  `andThen` allows different return types

### DIFF
--- a/src/main/java/io/vlingo/common/BasicCompletes.java
+++ b/src/main/java/io/vlingo/common/BasicCompletes.java
@@ -51,7 +51,7 @@ public class BasicCompletes<T> implements Completes<T> {
   @Override
   @SuppressWarnings("unchecked")
   public <O> Completes<O> andThen(final long timeout, final T failedOutcomeValue, final Function<T,O> function) {
-    return (Completes<O>) andThenInto(timeout, failedOutcomeValue, function);
+    return andThenInto(timeout, failedOutcomeValue, function.andThen(Completes::withSuccess));
   }
 
   @Override

--- a/src/main/java/io/vlingo/common/Completes.java
+++ b/src/main/java/io/vlingo/common/Completes.java
@@ -43,10 +43,10 @@ public interface Completes<T> {
     return new RepeatableCompletes<T>((T) null, false);
   }
 
-  Completes<T> andThen(final long timeout, final T failedOutcomeValue, final Function<T,T> function);
-  Completes<T> andThen(final T failedOutcomeValue, final Function<T,T> function);
-  Completes<T> andThen(final long timeout, final Function<T,T> function);
-  Completes<T> andThen(final Function<T,T> function);
+  <O> Completes<O> andThen(final long timeout, final T failedOutcomeValue, final Function<T,O> function);
+  <O> Completes<O> andThen(final T failedOutcomeValue, final Function<T,O> function);
+  <O> Completes<O> andThen(final long timeout, final Function<T,O> function);
+  <O> Completes<O> andThen(final Function<T,O> function);
 
   Completes<T> andThenConsume(final long timeout, final T failedOutcomeValue, final Consumer<T> consumer);
   Completes<T> andThenConsume(final T failedOutcomeValue, final Consumer<T> consumer);

--- a/src/main/java/io/vlingo/common/ResultCompletes.java
+++ b/src/main/java/io/vlingo/common/ResultCompletes.java
@@ -16,22 +16,22 @@ public class ResultCompletes implements Completes<Object> {
   public boolean __internal__outcomeSet = false;
 
   @Override
-  public Completes<Object> andThen(final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final long timeout, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final long timeout, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final Object failedOutcomeValue, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final Object failedOutcomeValue, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final long timeout, final Object failedOutcomeValue, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final long timeout, final Object failedOutcomeValue, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
Continuation of [vlingo-actors/pull/19](https://github.com/vlingo/vlingo-actors/pull/19).

Most of tests that fail is because it expects to have the reference to the previous `BasicCompletes`. Since the current `andThen` uses `andThenInto` as inner implementation (don't exposed to the end user), we lose that reference and state (to check `completes.hasFailed()`) to the previous `BasicCompletes` instance. 

Should we pass the `ActiveState` to the next `BasicCompletes`? I would like to fix the tests instead of chaning the current behaviour.