### PR TITLE
Add properties supporting environment variable interpolation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.2</version>

--- a/src/main/java/io/vlingo/common/config/EnvVarProperties.java
+++ b/src/main/java/io/vlingo/common/config/EnvVarProperties.java
@@ -1,0 +1,53 @@
+package io.vlingo.common.config;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EnvVarProperties extends Properties {
+    private static final Pattern envVarPattern = Pattern.compile("\\$\\{(?<envVar>[0-9a-zA-Z_]+)(:(?<default>[^\\}]+))?\\}");
+
+    /**
+     * Checks if the value contains a sequence to be interpolated (${&lt;ENV_VAR&gt;}) and
+     * replaces it with the value of the corresponding environment variable.
+     * <p>
+     * Default values can be specified after a colon in the variable: <code>${ENV_VAR:default}</code>
+     * <p>
+     * The implementation overrides <code>put</code> of the underlying <code>HashMap</code>
+     * to hook into the process of setting the value.
+     *
+     * @throws IllegalArgumentException if the environment variable is not set or either key or value are null
+     * @see Properties#setProperty
+     * @see Properties#load
+     */
+    @Override
+    public synchronized Object put(Object key, Object value) {
+        ensureKeyAndValueAreStrings(key, value);
+
+        StringBuffer interpolated = new StringBuffer();
+        Matcher matcher = envVarPattern.matcher((String) value);
+
+        while (matcher.find()) {
+            String envVal = System.getenv(matcher.group("envVar"));
+            String defaultVal = matcher.group("default");
+
+            ensureValueOrDefault((String) key, envVal, defaultVal);
+            matcher.appendReplacement(interpolated, envVal == null ? defaultVal : envVal);
+        }
+        matcher.appendTail(interpolated);
+
+        return super.put(key, interpolated.toString());
+    }
+
+    private void ensureKeyAndValueAreStrings(Object key, Object value) {
+        if (!(key instanceof String && value instanceof String)) {
+            throw new IllegalArgumentException("Both key and value need to be Strings");
+        }
+    }
+
+    private void ensureValueOrDefault(String key, String envVal, String defaultVal) {
+        if (envVal == null && defaultVal == null) {
+            throw new IllegalArgumentException("Environment variable " + key + " not set and has no default.");
+        }
+    }
+}

--- a/src/main/java/io/vlingo/common/config/EnvVarProperties.java
+++ b/src/main/java/io/vlingo/common/config/EnvVarProperties.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.common.config;
 
 import java.util.Properties;

--- a/src/main/java/io/vlingo/common/config/EnvVarProperties.java
+++ b/src/main/java/io/vlingo/common/config/EnvVarProperties.java
@@ -11,6 +11,23 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Properties implementation that supports interpolating properties from environment
+ * variable values.
+ *
+ * <br>
+ * Value syntax: <code>${<env var name>[:<default value>]}</code>
+ *
+ * <br>
+ * Examples:
+ *
+ * <ul>
+ *     <li><code>a=${FOO}; FOO=bar -> a=bar</code></li>
+ *     <li><code>a=${FOO}trag${BAZ}; FOO=un; BAZ=bar -> a=untragbar</code></li>
+ *     <li><code>a=${FOO:qux}; FOO=bar; -> a=bar</code></li>
+ *     <li><code>a=${FOO:qux}; FOO=<not net>; -> a=qux</code></li>
+ * </ul>
+ */
 public class EnvVarProperties extends Properties {
     private static final Pattern envVarPattern = Pattern.compile("\\$\\{(?<envVar>[0-9a-zA-Z_]+)(:(?<default>[^\\}]+))?\\}");
 

--- a/src/main/java/io/vlingo/common/config/EnvVarProperties.java
+++ b/src/main/java/io/vlingo/common/config/EnvVarProperties.java
@@ -22,10 +22,10 @@ import java.util.regex.Pattern;
  * Examples:
  *
  * <ul>
- *     <li><code>a=${FOO}; FOO=bar -> a=bar</code></li>
- *     <li><code>a=${FOO}trag${BAZ}; FOO=un; BAZ=bar -> a=untragbar</code></li>
- *     <li><code>a=${FOO:qux}; FOO=bar; -> a=bar</code></li>
- *     <li><code>a=${FOO:qux}; FOO=&lt;not set&gt;; -> a=qux</code></li>
+ *     <li><code>a=${FOO}; FOO=bar -&gt; a=bar</code></li>
+ *     <li><code>a=${FOO}trag${BAZ}; FOO=un; BAZ=bar -&gt; a=untragbar</code></li>
+ *     <li><code>a=${FOO:qux}; FOO=bar; -&gt; a=bar</code></li>
+ *     <li><code>a=${FOO:qux}; FOO=&lt;not set&gt; -&gt; a=qux</code></li>
  * </ul>
  */
 public class EnvVarProperties extends Properties {

--- a/src/main/java/io/vlingo/common/config/EnvVarProperties.java
+++ b/src/main/java/io/vlingo/common/config/EnvVarProperties.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  * variable values.
  *
  * <br>
- * Value syntax: <code>${<env var name>[:<default value>]}</code>
+ * Value syntax: <code>${&lt;env var name&gt;[:&lt;default value&gt;]}</code>
  *
  * <br>
  * Examples:
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  *     <li><code>a=${FOO}; FOO=bar -> a=bar</code></li>
  *     <li><code>a=${FOO}trag${BAZ}; FOO=un; BAZ=bar -> a=untragbar</code></li>
  *     <li><code>a=${FOO:qux}; FOO=bar; -> a=bar</code></li>
- *     <li><code>a=${FOO:qux}; FOO=<not net>; -> a=qux</code></li>
+ *     <li><code>a=${FOO:qux}; FOO=&lt;not set&gt;; -> a=qux</code></li>
  * </ul>
  */
 public class EnvVarProperties extends Properties {

--- a/src/test/java/io/vlingo/common/config/EnvVarPropertiesTest.java
+++ b/src/test/java/io/vlingo/common/config/EnvVarPropertiesTest.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.common.config;
 
 import org.junit.Rule;

--- a/src/test/java/io/vlingo/common/config/EnvVarPropertiesTest.java
+++ b/src/test/java/io/vlingo/common/config/EnvVarPropertiesTest.java
@@ -1,0 +1,106 @@
+package io.vlingo.common.config;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class EnvVarPropertiesTest {
+    @Rule
+    public final EnvironmentVariables envVars = new EnvironmentVariables();
+
+    @Test
+    public void envVarIsInterpolated() {
+        envVars.set("FOO", "bar");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO}");
+
+        assertEquals("bar", props.getProperty("p"));
+    }
+
+    @Test
+    public void multipleEnvVarsAreInterpolated() {
+        envVars.set("FOO", "baz");
+        envVars.set("BAR", "qux");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO}${BAR}");
+
+        assertEquals("bazqux", props.getProperty("p"));
+    }
+
+    @Test
+    public void envVarsAsSubstringAreInterpolated() {
+        envVars.set("NOUN", "base");
+        envVars.set("VERB", "belong");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "All your ${NOUN} are ${VERB} to us");
+
+        assertEquals("All your base are belong to us", props.getProperty("p"));
+    }
+
+    @Test
+    public void lowerCaseEnvVarsAreSupported() {
+        envVars.set("foo", "bar");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${foo}");
+
+        assertEquals("bar", props.getProperty("p"));
+    }
+
+    @Test
+    public void envVarsContainingDigitsAreSupported() {
+        envVars.set("F00", "baz");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${F00}");
+
+        assertEquals("baz", props.getProperty("p"));
+    }
+
+    @Test
+    public void envVarsContainingUnderscoresAreSupported() {
+        envVars.set("FOO_BAR", "baz");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO_BAR}");
+
+        assertEquals("baz", props.getProperty("p"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void inexistentEnvVarsThrow() {
+        envVars.set("FOO", null);
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO}");
+
+        fail("Interpolating an inexistent env var should have thrown an exception");
+    }
+
+    @Test
+    public void defaultsAreNotAppliedIfEnvIsSet() {
+        envVars.set("FOO", "bar");
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO:unused default}");
+        assertEquals("bar", props.getProperty("p"));
+    }
+
+    @Test
+    public void defaultsAreAppliedIfEnvIsNotSet() {
+        envVars.set("FOO", null);
+
+        Properties props = new EnvVarProperties();
+        props.setProperty("p", "${FOO:I am the default}");
+        assertEquals("I am the default", props.getProperty("p"));
+    }
+
+}


### PR DESCRIPTION
Adds a `java.util.Properties` extension that allows for interpolating values with data from the environment. Useful for adhering to https://12factor.net/config.

Value Syntax: `${<env var name>[:<default value>]}`

Examples:
* `a=${FOO}; FOO=bar` -> `a=bar`
* `a=${FOO}trag${BAZ}; FOO=un; BAZ=bar` -> `a=untragbar`
* `a=${FOO:qux}; FOO=bar;` -> `a=bar`
* `a=${FOO:qux}; FOO=<not net>;` -> `a=qux`

Required for https://github.com/vlingo/vlingo-schemata/issues/112