### PR TITLE
Allow for incrementing semantic version parts

### DIFF
--- a/src/main/java/io/vlingo/common/version/SemanticVersion.java
+++ b/src/main/java/io/vlingo/common/version/SemanticVersion.java
@@ -109,9 +109,13 @@ public class SemanticVersion {
     return new SemanticVersion(major, minor + 1, patch);
   }
 
-  public SemanticVersion withIncrementedPatch() {
-    return new SemanticVersion(major, minor, patch + 1);
-  }
+  public SemanticVersion withIncrementedPatch() { return new SemanticVersion(major, minor, patch + 1); }
+
+  public SemanticVersion nextPatch() { return withIncrementedPatch(); }
+
+  public SemanticVersion nextMinor() { return new SemanticVersion(major, minor + 1, 0); }
+
+  public SemanticVersion nextMajor() { return new SemanticVersion(major + 1, 0, 0); }
 
   @Override
   public int hashCode() {

--- a/src/main/java/io/vlingo/common/version/SemanticVersion.java
+++ b/src/main/java/io/vlingo/common/version/SemanticVersion.java
@@ -109,7 +109,9 @@ public class SemanticVersion {
     return new SemanticVersion(major, minor + 1, patch);
   }
 
-  public SemanticVersion withIncrementedPatch() { return new SemanticVersion(major, minor, patch + 1); }
+  public SemanticVersion withIncrementedPatch() {
+    return new SemanticVersion(major, minor, patch + 1);
+  }
 
   public SemanticVersion nextPatch() { return withIncrementedPatch(); }
 

--- a/src/test/java/io/vlingo/common/version/SemanticVersionTest.java
+++ b/src/test/java/io/vlingo/common/version/SemanticVersionTest.java
@@ -92,6 +92,15 @@ public class SemanticVersionTest {
   }
 
   @Test
+  public void testVersionIncrements() {
+    final SemanticVersion version = SemanticVersion.from(1, 2, 3);
+
+    assertEquals(version.nextPatch(), SemanticVersion.from(1, 2, 4));
+    assertEquals(version.nextMinor(), SemanticVersion.from(1, 3, 0));
+    assertEquals(version.nextMajor(), SemanticVersion.from(2, 0, 0));
+  }
+
+  @Test
   public void testVersionIncompatibility() {
     final SemanticVersion version = SemanticVersion.from(1, 0, 0);
 


### PR DESCRIPTION
Adds `nextPatch()`, `nextMinor()` and `nextMajor()` to `SemanticVersion`.
Required for https://github.com/vlingo/vlingo-schemata/pull/116