### PR TITLE
Do not flatten non-async outcomes

### DIFF
--- a/src/main/java/io/vlingo/common/completes/FutureCompletes.java
+++ b/src/main/java/io/vlingo/common/completes/FutureCompletes.java
@@ -476,7 +476,7 @@ public class FutureCompletes<T> implements Completes<T> {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     <O> State<O> nextForFunction(final O failedOutcomeValue, final Function<T, O> function, final boolean handlesFailure) {
-      Function<State<T>, CompletableFuture<O>> factory = (State<T> state) -> state.previousFuture().thenCompose(state.composableFunction(state.functionWrapper(function)));
+      Function<State<T>, CompletableFuture<O>> factory = (State<T> state) -> state.previousFuture().thenApply(state.functionWrapper(function));
       return new State(Completes.completesId(), this, scheduler, factory, failedOutcomeValue, handlesFailure, OutcomeType.Some);
     }
 

--- a/src/test/java/io/vlingo/common/completes/FutureCompletesTest.java
+++ b/src/test/java/io/vlingo/common/completes/FutureCompletesTest.java
@@ -76,6 +76,17 @@ public class FutureCompletesTest {
   }
 
   @Test
+  public void testThatNestedCompletesIsNotFlattened() {
+    final Completes<Integer> service = Completes.asInteger().with(5);
+
+    final Completes<Integer> client = service.andThen((value) -> Completes.withSuccess(value)).await();
+
+    client.await();
+
+    Assert.assertEquals(new Integer(5), client.outcome());
+  }
+
+  @Test
   public void testCompletesAfterLateDefinedConsumer() {
     final Completes<Integer> completes = Completes.asInteger().with(5);
 


### PR DESCRIPTION
[Schemata tests started failing](https://github.com/vlingo/vlingo-schemata/commit/066458401a304abfec94eb161c1832d378dacfe3/checks#step:7:1083) after merging [the new `Completes` implementation](https://github.com/vlingo/vlingo-common/pull/34):

```
04:26:28.469 [pool-136-thread-1] ERROR i.v.a.p.s.DefaultSupervisorOverride - DefaultSupervisorOverride: Failure of: Address[id=18, name=(none)] because: io.vlingo.schemata.codegen.ast.types.TypeDefinition cannot be cast to io.vlingo.common.Completes Action: Resuming.
java.lang.ClassCastException: io.vlingo.schemata.codegen.ast.types.TypeDefinition cannot be cast to io.vlingo.common.Completes
	at io.vlingo.schemata.codegen.TypeDefinitionCompilerActor.lambda$process$5(TypeDefinitionCompilerActor.java:56) ~[classes/:na]
	at io.vlingo.common.Success.andThen(Success.java:29) ~[vlingo-common-1.4.4-SNAPSHOT.jar:na]
	at io.vlingo.schemata.codegen.TypeDefinitionCompilerActor.compileToAST(TypeDefinitionCompilerActor.java:47) ~[classes/:na]
	at io.vlingo.schemata.model.SchemaVersionEntity.diff(SchemaVersionEntity.java:102) ~[classes/:na]
	at io.vlingo.schemata.model.SchemaVersion__Proxy.lambda$diff$a1aa88f9$1(SchemaVersion__Proxy.java:78) ~[classes/:na]
	at io.vlingo.actors.LocalMessage.internalDeliver(LocalMessage.java:121) ~[vlingo-actors-1.4.4-SNAPSHOT.jar:na]
	at io.vlingo.actors.LocalMessage.deliver(LocalMessage.java:53) ~[vlingo-actors-1.4.4-SNAPSHOT.jar:na]
	at io.vlingo.actors.plugin.mailbox.concurrentqueue.ConcurrentQueueMailbox.run(ConcurrentQueueMailbox.java:108) ~[vlingo-actors-1.4.4-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_282]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_282]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_282]
```

It's caused by the following code in schemata:

```
Completes<Node> result = Completes.withSuccess(node);
for (Processor p : processors) {
  result = result.andThen(n -> p.process(n, this, fullyQualifiedTypeName)).await();
}

return result.await();
```

`andThen` should not flatten the `Completes` outcome returned from its function like `andThenTo` does.

As a side note the above code should probably use `andThenTo` instead of `andThen`.